### PR TITLE
Refactoring, documentation improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- '6.11'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NYPL Streams Client
 
-Helper lib for interacting with the (internal) NYPL Streams
+This is a helper module for reading and writing to NYPL streams with/without Avro encoding.
 
 ## Installation
 
@@ -17,25 +17,9 @@ const NyplStreamsClient = require('@nypl/nypl-Streams-client')
 var streamsClient = new NyplStreamsClient({ nyplDataApiClientBase: 'http://example.com/api/v0.1/' })
 ```
 
-Client options include:
- - **nyplDataApiClientBase**: Base URL for the NYPL Data API, as required by [NYPL API client `base_url`](https://github.com/NYPL-discovery/node-nypl-data-api-client). (Alternatively use env NYPL_API_BASE_URL)
- - **writeBatchSize**: Batch size to use when writing records via `putRecords`. AWS max is 500. Default 500
- - **recordsPerSecond**: Max records to write to stream in a given second through any means. AWS max is 1000. Default 500
- - **waitBetweenDescribeCallsInSeconds**: Delay to insert between successive Describe calls (i.e. when checking stream availability. Default 4
- - **maxDescribeCallRetries**: Maximum number of Describe calls to make before failing. Default 10
- - **awsRegion**: AWS region that your kinesis streams are located in. Default 'us-east-1'
- - **logLevel**: Set [log level](https://github.com/pimterry/loglevel) (i.e. info, error, warn, debug). Default env.LOG_LEVEL or 'error'
+See [docs/usage.md](docs/usage.md) for complete documentation of Client methods and use.
 
-### streamsClient.write (streamName, data, opts)
-
-Returns a Promise that resolves when the given data has been written to the named stream.
-
-Params:
- - **streamName**: String name of stream to write to. (Also identifies the avro encoding to use.)
- - **data**: An object (or array of objects) to encode and write to the stream
- - **opts**: Optional options hash that may include:
-   - **avroEncode**: Boolean indicating whether or not to avro-encode the data before writing. Default `true`
-   - **avroSchemaName**: String schema name identifying avro schema to use when encoding data. Defaults to `streamName`.
+### Example 1: Writing data to a stream
 
 To write a single record to a stream (encoded to "MyStream" schema):
 ```js
@@ -57,14 +41,9 @@ streamsClient.write('MyStream', records, options).then((resp) => {
 
 Above will resolve after `records.length / 500` seconds. The resolved value is a hash merged from the hashes returned from each putRecords call.
 
+### Example 2: Decoding data obtained from a stream
 
-### streamsClient.decodeData (schemaName, data)
-
-A convenience function for decoding data received from a Kinesis stream (e.g. via a lambda event). Returns a Promise that resolves the record (or array of records) decoded.
-
-Params:
- - **schemaName**: String name of schema the data is encoded in.
- - **data**: An object (or array of objects) to decode.
+The streams client can be used for decoding data obtained directly from a stream (i.e. via a Lambda Kinesis source).
 
 Example lambda handler with a kinesis trigger:
 
@@ -85,28 +64,13 @@ exports.handler = function (event, context, callback) {
 }
 ```
 
-### streamsClient.decodeAvroBufferString (bufferString, avroObject, encodeType = 'base64')
+## Git workflow
 
-A convenience function for returning a decoded Avro Object from a given encoded Buffer
+ - Cut feature branch from master.
+ - Create PR to merge feature branch into master
+ - After PR approved by multiple co-workers, the author merges the PR.
+ - Tag master with an appropriate version bump and publish to NPMJS (See https://github.com/NYPL/engineering-general/blob/master/standards/versioning.md#npm-versioning )
 
-Params:
- - **bufferString** - String representing encoded buffer.
- - **avroObject** - Avro Object containing `fromBuffer` method used to decode the bufferString.
- - **encodeType** - String representing type of encoding, defaults to `base64`. (optional)
-
-Example:
-
-```js
-  const avsc = require('avsc')
-  // Initialize streams client:
-  const streamsClient = new NyplStreamsClient({ nyplDataApiClientBase: 'http://example.com/api/v0.1/' })
-  // Using the npm avsc module
-  const avroType = avsc.parse(JSON.parse(schema))
-  // Encoded buffer string
-  const bufferString = 'AEg5MzA4ZDMxMi0zZWQ0LTQ2ZjEtOWJiNS1iN'
-  // Result of decoded buffer string
-  const decodedBuffer = NyplStreamsClient.decodeAvroBufferString(bufferString, avroType)
-```
 
 ## Testing
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,207 @@
+## Classes
+
+<dl>
+<dt><a href="#Client">Client</a></dt>
+<dd></dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#ClientConstructorOptions">ClientConstructorOptions</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="#WriteOptions">WriteOptions</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="#WriteResponse">WriteResponse</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="#CreateStreamOptions">CreateStreamOptions</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="#DeleteStreamOptions">DeleteStreamOptions</a> : <code>Object</code></dt>
+<dd></dd>
+</dl>
+
+<a name="Client"></a>
+
+## Client
+**Kind**: global class  
+
+* [Client](#Client)
+    * [new Client(options)](#new_Client_new)
+    * [.write(streamName, data, options)](#Client+write) ⇒ <code>Promise.&lt;WriteReponse&gt;</code>
+    * [.createStream(name, options)](#Client+createStream) ⇒ <code>Promise</code>
+    * [.deleteStream(name, options)](#Client+deleteStream) ⇒ <code>Promise</code>
+    * [.kinesisClient()](#Client+kinesisClient) ⇒ <code>Promise.&lt;AWS.Kinesis&gt;</code>
+    * [.dataApiClient()](#Client+dataApiClient) ⇒ <code>Promise.&lt;NyplClient&gt;</code>
+    * [.encodeData(schemaName, data)](#Client+encodeData) ⇒ <code>Promise</code>
+    * [.decodeData(schemaName, data)](#Client+decodeData) ⇒ <code>Promise</code>
+    * [.decodeAvroBufferString(bufferString, avroObject, encodeType)](#Client+decodeAvroBufferString) ⇒
+    * [.getAvroType()](#Client+getAvroType) ⇒ <code>Promise.&lt;avsc.Type&gt;</code>
+
+<a name="new_Client_new"></a>
+
+### new Client(options)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | [<code>ClientConstructorOptions</code>](#ClientConstructorOptions) | A hash of options |
+
+<a name="Client+write"></a>
+
+### client.write(streamName, data, options) ⇒ <code>Promise.&lt;WriteReponse&gt;</code>
+Write data to named stream.
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: <code>Promise.&lt;WriteReponse&gt;</code> - A promise that resolves a WriteReponse obj
+
+Note, the `data` arg can be an object or array of objects.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| streamName | <code>string</code> | Name of stream to write to. |
+| data | <code>Object</code> \| <code>Array</code> | Object (or array of objects) to write. |
+| options | [<code>WriteOptions</code>](#WriteOptions) |  |
+
+<a name="Client+createStream"></a>
+
+### client.createStream(name, options) ⇒ <code>Promise</code>
+Create a stream by name
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: <code>Promise</code> - A promise that resolves on success.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | Name of stream |
+| options | [<code>CreateStreamOptions</code>](#CreateStreamOptions) |  |
+
+<a name="Client+deleteStream"></a>
+
+### client.deleteStream(name, options) ⇒ <code>Promise</code>
+Delete a stream by name
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: <code>Promise</code> - A promise that resolves on success.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | Name of stream |
+| options | <code>CreateOptions</code> |  |
+
+<a name="Client+kinesisClient"></a>
+
+### client.kinesisClient() ⇒ <code>Promise.&lt;AWS.Kinesis&gt;</code>
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: <code>Promise.&lt;AWS.Kinesis&gt;</code> - A Promise that resolves an instance of
+    AWS.Kinesis  
+<a name="Client+dataApiClient"></a>
+
+### client.dataApiClient() ⇒ <code>Promise.&lt;NyplClient&gt;</code>
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: <code>Promise.&lt;NyplClient&gt;</code> - A Promise that resolves an instance of
+    the NYPL Data API Client
+    ( https://www.npmjs.com/package/@nypl/nypl-data-api-client )  
+<a name="Client+encodeData"></a>
+
+### client.encodeData(schemaName, data) ⇒ <code>Promise</code>
+Returns Promise that resolves the given data encoded against the named schema
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+
+| Param | Type |
+| --- | --- |
+| schemaName | <code>String</code> | 
+| data | <code>Object</code> \| <code>String</code> | 
+
+<a name="Client+decodeData"></a>
+
+### client.decodeData(schemaName, data) ⇒ <code>Promise</code>
+Returns a Promise that resolves the given data decoded against the given schema.
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+
+| Param | Type |
+| --- | --- |
+| schemaName | <code>String</code> | 
+| data | <code>Object</code> \| <code>String</code> | 
+
+<a name="Client+decodeAvroBufferString"></a>
+
+### client.decodeAvroBufferString(bufferString, avroObject, encodeType) ⇒
+Returns a decoded Avro Object from a given encoded Buffer
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: Returns a deserialized buffer  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| bufferString | <code>String</code> |  |  |
+| avroObject | <code>Object</code> |  |  |
+| encodeType | <code>String</code> | <code>base64</code> | default encode type base64. |
+
+<a name="Client+getAvroType"></a>
+
+### client.getAvroType() ⇒ <code>Promise.&lt;avsc.Type&gt;</code>
+Returns an avro type instance by schema name
+
+**Kind**: instance method of [<code>Client</code>](#Client)  
+**Returns**: <code>Promise.&lt;avsc.Type&gt;</code> - A Promise that resolves an avsc.Type instance  
+<a name="ClientConstructorOptions"></a>
+
+## ClientConstructorOptions : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| nyplDataApiClientBase | <code>string</code> | Base URL for API (e.g. 'https://[FQDN]/api/v0.1/').    If missing, client will check process.env.NYPL_API_BASE_URL |
+| writeBatchSize | <code>number</code> | How many records to write to a stream    at once. Default 500.    http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html |
+| recordsPerSecond | <code>number</code> | How many records to write to a    stream in a single 1s period. Default 500. AWS max is 1000/s. See:    http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html |
+| waitBetweenDescribeCallsInSeconds | <code>number</code> | How many seconds to    pause between describe calls (i.e. when waiting for active stream).    Default 4 |
+| maxDescribeCallRetries | <code>number</code> | Maximum describe calls to make    before giving up (i.e. when waiting for active stream). Default 10. |
+| logLevel | <code>string</code> | Set [log level](https://github.com/pimterry/loglevel)    (i.e. info, error, warn, debug). Default env.LOG_LEVEL or 'error' |
+| awsRegion | <code>string</code> | AWS region to use. Default us-east-1 |
+
+<a name="WriteOptions"></a>
+
+## WriteOptions : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| avroEncode | <code>boolean</code> | Whether or not to Name of avro schema to use to encode. |
+| avroSchemaName | <code>string</code> | Name of avro schema to use to encode.     Defaults to `streamName`. |
+
+<a name="WriteResponse"></a>
+
+## WriteResponse : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| Records | <code>Array</code> | Array of records written |
+| FailedRecordCount | <code>number</code> | Number of records that failed |
+| unmergedResponses | <code>Array</code> | Raw AWS responses (for debugging     mult. batch jobs) |
+
+<a name="CreateStreamOptions"></a>
+
+## CreateStreamOptions : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| shards | <code>number</code> | <code>1</code> | Number of shards to attach to stream |
+| failIfExists | <code>boolean</code> | <code>false</code> | Whether to throw error if stream     already exists. |
+
+<a name="DeleteStreamOptions"></a>
+
+## DeleteStreamOptions : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| yesIKnowThisIsPotentiallyDisastrous | <code>boolean</code> | <code>false</code> | Flag that     must be set to true to allow call to succeed. |
+

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const log = require('loglevel').getLogger('nypl-streams-client')
 const AWS = require('aws-sdk')
 const NyplClient = require('@nypl/nypl-data-api-client')
@@ -34,7 +32,30 @@ AvroValidationError._getAvroValidationIssues = function (obj, type) {
  */
 
 class Client {
+  /**
+   * @typedef {Object} ClientConstructorOptions
+   * @property {string} nyplDataApiClientBase - Base URL for API (e.g. 'https://[FQDN]/api/v0.1/').
+   *    If missing, client will check process.env.NYPL_API_BASE_URL
+   * @property {number} writeBatchSize - How many records to write to a stream
+   *    at once. Default 500.
+   *    http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
+   * @property {number} recordsPerSecond - How many records to write to a
+   *    stream in a single 1s period. Default 500. AWS max is 1000/s. See:
+   *    http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
+   * @property {number} waitBetweenDescribeCallsInSeconds - How many seconds to
+   *    pause between describe calls (i.e. when waiting for active stream).
+   *    Default 4
+   * @property {number} maxDescribeCallRetries - Maximum describe calls to make
+   *    before giving up (i.e. when waiting for active stream). Default 10.
+   * @property {string} logLevel - Set [log level](https://github.com/pimterry/loglevel)
+   *    (i.e. info, error, warn, debug). Default env.LOG_LEVEL or 'error'
+   * @property {string} awsRegion - AWS region to use. Default us-east-1
+   */
 
+  /**
+   * @constructs Client
+   * @param {ClientConstructorOptions} options - A hash of options
+   */
   constructor (opts) {
     opts = opts || {}
     this.options = Object.assign({
@@ -53,11 +74,37 @@ class Client {
     this._writeQueue = {}
   }
 
-  write (name, data, opts) {
+  /**
+   * @typedef {Object} WriteOptions
+   * @property {boolean} avroEncode - Whether or not to Name of avro schema to use to encode.
+   * @property {string} avroSchemaName - Name of avro schema to use to encode.
+   *     Defaults to `streamName`.
+   */
+
+  /**
+   * @typedef {Object} WriteResponse
+   * @property {Array} Records - Array of records written
+   * @property {number} FailedRecordCount - Number of records that failed
+   * @property {Array} unmergedResponses - Raw AWS responses (for debugging
+   *     mult. batch jobs)
+   */
+
+  /**
+   * Write data to named stream.
+   *
+   * @param {string} streamName - Name of stream to write to.
+   * @param {Object|Array} data - Object (or array of objects) to write.
+   * @param {WriteOptions} options
+   *
+   * @return {Promise<WriteReponse>} A promise that resolves a WriteReponse obj
+   *
+   * Note, the `data` arg can be an object or array of objects.
+   */
+  write (streamName, data, opts) {
     opts = opts || {}
     opts = Object.assign({
       avroEncode: true,
-      avroSchemaName: name
+      avroSchemaName: streamName
     }, opts)
 
     // Ensure data is encoded (or not) as appropriate:
@@ -68,158 +115,32 @@ class Client {
       return this.kinesisClient().then((kinesis) => {
         var debugLabels = Array.isArray(data) ? data.slice(0, 3).map((r) => r.id).join(', ') + ', ...' : data.id
 
-        log.debug('Queuing ' + debugLabels + ' to ' + name)
+        log.debug('Queuing ' + debugLabels + ' to ' + streamName)
 
-        return (Array.isArray(preparedData) ? this._writeMultiple(kinesis, name, preparedData) : this._writeOne(kinesis, name, preparedData))
+        return (Array.isArray(preparedData) ? this._writeMultiple(kinesis, streamName, preparedData) : this._writeOne(kinesis, streamName, preparedData))
           .then((resp) => {
-            log.info(`Successfully sent ${debugLabels} to ${name} kinesis.`)
+            log.info(`Successfully sent ${debugLabels} to ${streamName} kinesis.`)
             return resp
           })
       })
     })
   }
 
-  _writeMultiple (kinesis, name, preparedData) {
-    // Don't write more than batch size or more than the records-per-second constraint:
-    var effectiveWriteSize = Math.min(this.options.writeBatchSize, this.options.recordsPerSecond)
-    log.debug('Effective write size: %s', effectiveWriteSize)
+  /**
+   * @typedef {Object} CreateStreamOptions
+   * @property {number} shards=1 - Number of shards to attach to stream
+   * @property {boolean} failIfExists=false - Whether to throw error if stream
+   *     already exists.
+   */
 
-    return Promise.all(
-      utils.arrayChunk(preparedData, effectiveWriteSize).map((chunkedPreparedData, i) => {
-        // Call the appropriate put endpoint:
-        return new Promise((resolve, reject) => {
-          // Set up params to send to kinesis:
-          var recordParams = {
-            StreamName: name // kinesisWriteStream.stream
-          }
-          // Payload is an array of records:
-          recordParams.Records = chunkedPreparedData.map((rec) => ({
-            Data: rec,
-            PartitionKey: 'sensor-' + Math.floor(Math.random() * 100000)
-          }))
-
-          log.debug('Queuing chunk ' + i + ' (' + chunkedPreparedData.length + ' records)')
-          this.queueWriteCall(name, recordParams.Records.length, () => {
-            kinesis.putRecords(recordParams, (err, resp) => {
-              if (err) {
-                log.error(err)
-                reject(err)
-              } else {
-                resolve(resp)
-              }
-            })
-          })
-        }).then((resp) => {
-          return resp
-        })
-      })
-    ).then((responses) => {
-      // Combine all responses into a common response doc to ease analysis:
-      return responses.reduce((all, resp) => {
-        all.Records = all.Records.concat(resp.Records)
-        all.FailedRecordCount += resp.FailedRecordCount
-        return all
-      }, { FailedRecordCount: 0, Records: [], unmergedResponses: responses })
-    }).catch((e) => {
-      console.log('ERRROR: ', e)
-    })
-  }
-
-  queueWriteCall (streamName, count, exec) {
-    if (!this._writeQueue[streamName]) this._writeQueue[streamName] = []
-    this._writeQueue[streamName].push({ count, exec })
-
-    // In case it's not yet running, start processing:
-    this.considerProcessingWriteQueue()
-  }
-
-  considerProcessingWriteQueue () {
-    // process write-queue if there's not already a worker queued to do just that
-    if (!this._processTimeoutHandler) this.processWriteQueue()
-  }
-
-  processWriteQueue () {
-    // Count the total number left to process in all streams:
-    var totalToProcess = Object.keys(this._writeQueue).reduce((total, streamName) => {
-      return total + this._writeQueue[streamName].reduce((subtotal, batch) => subtotal + batch.count, 0)
-    }, 0)
-    // log.debug('Total left to proces: ' + totalToProcess)
-
-    // If nothing to process, nullify handler so that we know there's nothing pending
-    if (totalToProcess === 0) {
-      this._processTimeoutHandler = null
-      log.debug('Nothing left to process, pausing')
-      return
-    }
-
-    Object.keys(this._writeQueue).map((streamName) => {
-      while (true) {
-        // Nothing more to process? Continue
-        if (this._writeQueue[streamName].length === 0) break
-
-        // Get next batch count so we know whether or not to process it
-        var nextCount = this._writeQueue[streamName][0].count
-
-        // If writing another batch would exceed limit, delay:
-        if (this.writesSince(streamName) + nextCount <= this.options.recordsPerSecond) {
-          // Grab next batch:
-          var batch = this._writeQueue[streamName].shift()
-
-          log.debug('Executing call on ' + streamName + ' w/size: ' + batch.count)
-          this.logWriteCall(streamName, batch.count)
-          batch.exec()
-        } else {
-          log.debug('Waiting to process ' + streamName + ' because consuming more would exceed ' + this.options.recordsPerSecond + '/s')
-          // Consuming more would exceed rate, so queue
-          break
-        }
-      }
-    })
-
-    this._processTimeoutHandler = setTimeout(() => this.processWriteQueue(), 100)
-  }
-
-  writesSince (streamName, seconds) {
-    seconds = (typeof seconds) === 'undefined' ? 1 : seconds
-
-    if (!this._writesByStream[streamName]) return 0
-
-    var since = (new Date()).getTime() - seconds * 1000
-    return this._writesByStream[streamName].reduce((count, log) => {
-      if (log.time >= since) count += log.count
-      return count
-    }, 0)
-  }
-
-  logWriteCall (streamName, count) {
-    if (!this._writesByStream[streamName]) this._writesByStream[streamName] = []
-    this._writesByStream[streamName].push({ count, time: (new Date()).getTime() })
-  }
-
-  _writeOne (kinesis, name, preparedData) {
-    // Set up params to send to kinesis:
-    var recordParams = {
-      StreamName: name // kinesisWriteStream.stream
-    }
-    // Payload is the record itself:
-    recordParams.Data = preparedData
-    recordParams.PartitionKey = 'sensor-' + Math.floor(Math.random() * 100000)
-
-    return new Promise((resolve, reject) => {
-      // Queue it to run
-      this.queueWriteCall(name, 1, () => {
-        kinesis.putRecord(recordParams, (err, resp) => {
-          if (err) {
-            log.error(err)
-            reject(err)
-          } else {
-            resolve(resp)
-          }
-        })
-      })
-    })
-  }
-
+  /**
+   * Create a stream by name
+   *
+   * @param {string} name - Name of stream
+   * @param {CreateStreamOptions} options
+   *
+   * @return {Promise} A promise that resolves on success.
+   */
   createStream (name, options) {
     options = options || {}
     options = Object.assign({
@@ -238,10 +159,9 @@ class Client {
           if (err) {
             if (err.code !== 'ResourceInUseException') {
               reject(err)
-              return
             } else {
               log.debug('%s stream is already created.', name)
-              if (options.failIfExists) reject('Already exists: ' + name)
+              if (options.failIfExists) reject(new Error('Already exists: ' + name))
               else resolve()
             }
           } else {
@@ -255,13 +175,27 @@ class Client {
     })
   }
 
+  /**
+   * @typedef {Object} DeleteStreamOptions
+   * @property {boolean} yesIKnowThisIsPotentiallyDisastrous=false - Flag that
+   *     must be set to true to allow call to succeed.
+   */
+
+  /**
+   * Delete a stream by name
+   *
+   * @param {string} name - Name of stream
+   * @param {DeleteStreamOptions} options
+   *
+   * @return {Promise} A promise that resolves on success.
+   */
   deleteStream (name, options) {
     options = options || {}
     options = Object.assign({
       yesIKnowThisIsPotentiallyDisastrous: false
     }, options)
 
-    if (!options.yesIKnowThisIsPotentiallyDisastrous) return Promise.reject('Failing stream deletion because options.yesIKnowThisIsPotentiallyDisastrous is not set to TRUE')
+    if (!options.yesIKnowThisIsPotentiallyDisastrous) return Promise.reject(new Error('Failing stream deletion because options.yesIKnowThisIsPotentiallyDisastrous is not set to TRUE'))
 
     var params = {
       StreamName: name
@@ -277,12 +211,21 @@ class Client {
     })
   }
 
+  /**
+   * @return {Promise<AWS.Kinesis>} A Promise that resolves an instance of
+   *     AWS.Kinesis
+   */
   kinesisClient () {
     if (!this.__kinesisClient) this.__kinesisClient = new AWS.Kinesis({ region: this.options.awsRegion })
 
     return Promise.resolve(this.__kinesisClient)
   }
 
+  /**
+   * @return {Promise<NyplClient>} A Promise that resolves an instance of
+   *     the NYPL Data API Client
+   *     ( https://www.npmjs.com/package/@nypl/nypl-data-api-client )
+   */
   dataApiClient () {
     if (!this.__dataApiClient) this.__dataApiClient = new NyplClient({ base_url: this.options.nyplDataApiClientBase })
 
@@ -372,7 +315,9 @@ class Client {
   }
 
   /**
-   * Returns a Promise that resolves a avsc.Type instance by schema name
+   * Returns an avro type instance by schema name
+   *
+   * @return {Promise<avsc.Type>} A Promise that resolves an avsc.Type instance
    */
   getAvroType (schemaName) {
     return this.dataApiClient().then((api) => {
@@ -383,6 +328,219 @@ class Client {
     })
   }
 
+  /**
+   * Write array of prepared data to stream.
+   *
+   * @param {AWS.Kinesis} kinesis - AWS.Kinesis client instance
+   * @param {string} name - Stream name
+   * @param {array<string>} preparedData - Array of prepared data to be written
+   *
+   * @private
+   *
+   * @return {Promise<WriteReponse>} A promise that resolves a WriteReponse obj
+   */
+  _writeMultiple (kinesis, name, preparedData) {
+    // Don't write more than batch size or more than the records-per-second constraint:
+    var effectiveWriteSize = Math.min(this.options.writeBatchSize, this.options.recordsPerSecond)
+    log.debug('Effective write size: %s', effectiveWriteSize)
+
+    return Promise.all(
+      utils.arrayChunk(preparedData, effectiveWriteSize).map((chunkedPreparedData, i) => {
+        // Call the appropriate put endpoint:
+        return new Promise((resolve, reject) => {
+          // Set up params to send to kinesis:
+          var recordParams = {
+            StreamName: name // kinesisWriteStream.stream
+          }
+          // Payload is an array of records:
+          recordParams.Records = chunkedPreparedData.map((rec) => ({
+            Data: rec,
+            PartitionKey: 'sensor-' + Math.floor(Math.random() * 100000)
+          }))
+
+          log.debug('Queuing chunk ' + i + ' (' + chunkedPreparedData.length + ' records)')
+          this._queueWriteCall(name, recordParams.Records.length, () => {
+            kinesis.putRecords(recordParams, (err, resp) => {
+              if (err) {
+                log.error(err)
+                reject(err)
+              } else {
+                resolve(resp)
+              }
+            })
+          })
+        }).then((resp) => {
+          return resp
+        })
+      })
+    ).then((responses) => {
+      // Combine all responses into a common response doc to ease analysis:
+      return responses.reduce((all, resp) => {
+        all.Records = all.Records.concat(resp.Records)
+        all.FailedRecordCount += resp.FailedRecordCount
+        return all
+      }, { FailedRecordCount: 0, Records: [], unmergedResponses: responses })
+    }).catch((e) => {
+      console.log('ERRROR: ', e)
+    })
+  }
+
+  /**
+   * Enqueue a write task
+   *
+   * @private
+   *
+   * @param {string} streamName - Name of stream
+   * @param {number} count - Number of records the call will write
+   * @param {function} exec - Function to fire to execute job.
+   */
+  _queueWriteCall (streamName, count, exec) {
+    if (!this._writeQueue[streamName]) this._writeQueue[streamName] = []
+    this._writeQueue[streamName].push({ count, exec })
+
+    // In case it's not yet running, start processing:
+    this._considerProcessingWriteQueue()
+  }
+
+  /**
+   * Invoke processWriteQueue if such a call has not already been queued.
+   *
+   * @private
+   */
+  _considerProcessingWriteQueue () {
+    // process write-queue if there's not already a worker queued to do just that
+    if (!this._processTimeoutHandler) this._processWriteQueue()
+  }
+
+  /**
+   * This method runs periodically to flush as many write jobs off the write
+   * queue as it can without violating write size/speed constraints.
+   *
+   * @private
+   */
+  _processWriteQueue () {
+    // Count the total number left to process in all streams:
+    var totalToProcess = Object.keys(this._writeQueue).reduce((total, streamName) => {
+      return total + this._writeQueue[streamName].reduce((subtotal, batch) => subtotal + batch.count, 0)
+    }, 0)
+    // log.debug('Total left to proces: ' + totalToProcess)
+
+    // If nothing to process, nullify handler so that we know there's nothing pending
+    if (totalToProcess === 0) {
+      this._processTimeoutHandler = null
+      log.debug('Nothing left to process, pausing')
+      return
+    }
+
+    Object.keys(this._writeQueue).map((streamName) => {
+      while (true) {
+        // Nothing more to process? Continue
+        if (this._writeQueue[streamName].length === 0) break
+
+        // Get next batch count so we know whether or not to process it
+        var nextCount = this._writeQueue[streamName][0].count
+
+        // If writing another batch would exceed limit, delay:
+        if (this._writesSince(streamName) + nextCount <= this.options.recordsPerSecond) {
+          // Grab next batch:
+          var batch = this._writeQueue[streamName].shift()
+
+          log.debug('Executing call on ' + streamName + ' w/size: ' + batch.count)
+          this._logWriteCall(streamName, batch.count)
+          batch.exec()
+        } else {
+          log.debug('Waiting to process ' + streamName + ' because consuming more would exceed ' + this.options.recordsPerSecond + '/s')
+          // Consuming more would exceed rate, so queue
+          break
+        }
+      }
+    })
+
+    this._processTimeoutHandler = setTimeout(() => this._processWriteQueue(), 100)
+  }
+
+  /**
+   * Get number of records written in last N seconds. For N=1, useful for
+   * determining how many more records we can write in the present moment
+   * without exceeding our established writes/s boundary.
+   *
+   * @private
+   *
+   * @param {string} streamName - Stream name
+   * @param {number} seconds=1 - Number of seconds of history to sum
+   *
+   * @return {number} Number of writes
+   */
+
+  _writesSince (streamName, seconds) {
+    seconds = (typeof seconds) === 'undefined' ? 1 : seconds
+
+    if (!this._writesByStream[streamName]) return 0
+
+    var since = (new Date()).getTime() - seconds * 1000
+    return this._writesByStream[streamName].reduce((count, log) => {
+      if (log.time >= since) count += log.count
+      return count
+    }, 0)
+  }
+
+  /**
+   * Register that we have written `count` records to stream
+   *
+   * @private
+   *
+   * @param {string} streamName - Name of stream
+   * @param {number} count - Number of records written
+   */
+  _logWriteCall (streamName, count) {
+    if (!this._writesByStream[streamName]) this._writesByStream[streamName] = []
+    this._writesByStream[streamName].push({ count, time: (new Date()).getTime() })
+  }
+
+  /**
+   * Write single prepared data object to stream.
+   *
+   * @private
+   *
+   * @param {AWS.Kinesis} kinesis - AWS.Kinesis client instance
+   * @param {string} name - Stream name
+   * @param {string} preparedData - Single prepared data to write
+   *
+   * @return {Promise<WriteReponse>} A promise that resolves a WriteReponse obj
+   */
+  _writeOne (kinesis, name, preparedData) {
+    // Set up params to send to kinesis:
+    var recordParams = {
+      StreamName: name // kinesisWriteStream.stream
+    }
+    // Payload is the record itself:
+    recordParams.Data = preparedData
+    recordParams.PartitionKey = 'sensor-' + Math.floor(Math.random() * 100000)
+
+    return new Promise((resolve, reject) => {
+      // Queue it to run
+      this._queueWriteCall(name, 1, () => {
+        kinesis.putRecord(recordParams, (err, resp) => {
+          if (err) {
+            log.error(err)
+            reject(err)
+          } else {
+            resolve(resp)
+          }
+        })
+      })
+    })
+  }
+
+  /**
+   * Wait for a named stream to become active.
+   *
+   * @param {string} name - Name of stream.
+   *
+   * @private
+   *
+   * @return {Promise} A proimse that resolves when the named stream is active.
+   */
   _waitForStreamToBecomeActive (name, count) {
     count = count || 1
     log.debug('_waitForStreamToBecomeActive')
@@ -396,7 +554,7 @@ class Client {
             if (data.StreamDescription.StreamStatus === 'ACTIVE') {
               resolve()
             } else if (count === this.options.maxDescribeCallRetries) {
-              reject('Failure to go ACTIVE: %s after %s retries', name, count)
+              reject(new Error(`Failure to go ACTIVE: ${name} after ${count} retries`))
             } else {
               setTimeout(() => {
                 this._waitForStreamToBecomeActive(name, count + 1).then(resolve)
@@ -407,7 +565,6 @@ class Client {
       })
     })
   }
-
 }
 
 module.exports = Client

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,9 @@ const avsc = require('avsc')
 
 const utils = require('./utils')
 
+/**
+ * A AvroValidationError is thrown when avsc fails to encode/decode data.
+ */
 function AvroValidationError (avroType, data) {
   this.name = 'AvroValidationError'
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -165,7 +165,6 @@ class Client {
     }
 
     Object.keys(this._writeQueue).map((streamName) => {
-      // console.log('Processing ' + streamName, this._writeQueue[streamName])
       while (true) {
         // Nothing more to process? Continue
         if (this._writeQueue[streamName].length === 0) break

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,4 +9,3 @@ module.exports.arrayChunk = function (a, size) {
     return chunks
   }, [])
 }
-

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "unit-test": "./node_modules/.bin/mocha --reporter spec",
-    "test": "standard && npm run unit-test"
+    "test": "./node_modules/.bin/standard && npm run unit-test",
+    "build-jsdoc": "./node_modules/.bin/jsdoc2md lib/client.js > docs/usage.md"
   },
   "author": "@nonword",
   "license": "ISC",
@@ -20,8 +21,10 @@
     "aws-sdk-mock": "^1.7.0",
     "chai": "4.0.2",
     "chai-as-promised": "7.0.0",
+    "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^3.2.0",
-    "sinon": "^4.0.1"
+    "sinon": "^4.0.1",
+    "standard": "^11.0.1"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "unit-test": "./node_modules/.bin/mocha --reporter spec",
-    "test": "./node_modules/.bin/standard && npm run unit-test",
+    "test": "./node_modules/.bin/standard --env mocha && npm run unit-test",
     "build-jsdoc": "./node_modules/.bin/jsdoc2md lib/client.js > docs/usage.md"
   },
   "author": "@nonword",
@@ -22,6 +22,7 @@
     "chai": "4.0.2",
     "chai-as-promised": "7.0.0",
     "jsdoc-to-markdown": "^4.0.1",
+    "md5": "^2.2.1",
     "mocha": "^3.2.0",
     "sinon": "^4.0.1",
     "standard": "^11.0.1"

--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
   "author": "@nonword",
   "license": "ISC",
   "dependencies": {
-    "@nypl/nypl-data-api-client": "^0.1.1",
+    "@nypl/nypl-data-api-client": "^0.2.5",
     "avsc": "^5.0.2",
     "aws-sdk": "^2.50.0",
     "loglevel": "^1.4.1",
     "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "aws-sdk-mock": "^1.7.0",
+    "mocha": "^3.2.0",
+    "sinon": "^4.0.1"
   },
   "directories": {
     "test": "test"

--- a/test/create-delete-stream-test.js
+++ b/test/create-delete-stream-test.js
@@ -20,7 +20,7 @@ describe('Client', function () {
           // Let's always respond to createStream requests for this stream name
           // as though it already exists (i.e. throw error like aws-sdk does)
           case 'fake-stream-name-that-exists':
-            callback('oh no!')
+            callback(new Error('oh no!'))
             break
         }
       })

--- a/test/decoding.test.js
+++ b/test/decoding.test.js
@@ -1,16 +1,25 @@
-/* global describe it */
 const chai = require('chai')
 const assert = chai.assert
 const expect = chai.expect
 const chaiAsPromised = require('chai-as-promised')
+
+const fixtures = require('./fixtures')
 const Client = require('../index')
 chai.use(chaiAsPromised)
 
 describe('Client', function () {
   this.timeout(30000)
 
+  before(function () {
+    fixtures.enableFixtures()
+  })
+
+  after(function () {
+    fixtures.disableFixtures()
+  })
+
   describe('Stream Client Decoding from Schema', () => {
-    const client = new Client({ nyplDataApiClientBase: 'https://api.nypltech.org/api/v0.1/' })
+    const client = new Client()
     const singleRecord = {
       'Records': [
         {

--- a/test/decoding.test.js
+++ b/test/decoding.test.js
@@ -92,7 +92,7 @@ describe('Client', function () {
     it('should fail if the schema is not valid', () => {
       const incorrectSchema = 'IndexLaLaLa'
       const decodedData = client.decodeData(incorrectSchema, singleRecord.Records[0].kinesis.data)
-      expect(decodedData).to.be.rejected
+      expect(decodedData).to.be.rejectedWith(Error)
     })
 
     it('should fail if the encoded string does NOT match the Schema', () => {

--- a/test/encoding.test.js
+++ b/test/encoding.test.js
@@ -1,13 +1,25 @@
-/* global describe it */
+/* global describe it before after */
 
+const AWS = require('aws-sdk-mock')
 const assert = require('assert')
 const Client = require('../index')
 
 describe('Client', function () {
-  this.timeout(30000)
-
   describe('Stream encoding', function () {
-    var streamName = 'node-nypl-streams-client-test-14948860293950.8801324877422303'
+    before(() => {
+      // Mock AWS.Kinesis.prototype.putRecords
+      AWS.mock('Kinesis', 'putRecords', function (params, callback) {
+        callback(null, 'All records have totally been put')
+      })
+      // Mock AWS.Kinesis.prototype.putRecord (singular)
+      AWS.mock('Kinesis', 'putRecord', function (params, callback) {
+        callback(null, 'That record, it is now put')
+      })
+    })
+
+    after(() => {
+      AWS.restore('Kinesis')
+    })
 
     it('should fail if single record fails to encode', function () {
       var client = new Client({ nyplDataApiClientBase: 'https://api.nypltech.org/api/v0.1/' })
@@ -17,7 +29,7 @@ describe('Client', function () {
         nyplSourceInvalidProp: 'sierra-nypl',
         nyplType: 'bib'
       }
-      return client.write(streamName, data, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
+      return client.write('fake-stream-name', data, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
         // By virtue of resolving, we know it didn't fail as it should
         assert(false)
       }).catch((e) => {
@@ -40,7 +52,7 @@ describe('Client', function () {
       // Delete a property from fourth record:
       delete multiple[3].nyplType
 
-      return client.write(streamName, multiple, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
+      return client.write('fake-stream-name', multiple, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
         // By virtue of resolving, we know it didn't fail as it should
         assert(false)
       }).catch((e) => {

--- a/test/encoding.test.js
+++ b/test/encoding.test.js
@@ -1,12 +1,15 @@
-/* global describe it before after */
-
 const AWS = require('aws-sdk-mock')
 const assert = require('assert')
+
+const fixtures = require('./fixtures')
 const Client = require('../index')
 
 describe('Client', function () {
   describe('Stream encoding', function () {
     before(() => {
+      // Enable api client fixtures
+      fixtures.enableFixtures()
+
       // Mock AWS.Kinesis.prototype.putRecords
       AWS.mock('Kinesis', 'putRecords', function (params, callback) {
         callback(null, 'All records have totally been put')
@@ -18,11 +21,14 @@ describe('Client', function () {
     })
 
     after(() => {
+      // Disable api client fixtures
+      fixtures.disableFixtures()
+
       AWS.restore('Kinesis')
     })
 
     it('should fail if single record fails to encode', function () {
-      var client = new Client({ nyplDataApiClientBase: 'https://api.nypltech.org/api/v0.1/' })
+      var client = new Client()
 
       var data = {
         id: '12000000',
@@ -39,7 +45,7 @@ describe('Client', function () {
     })
 
     it('should fail all if single record in batch fails to encode', function () {
-      var client = new Client({ nyplDataApiClientBase: 'https://api.nypltech.org/api/v0.1/' })
+      var client = new Client()
 
       var data = {
         id: '12000000',

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,113 @@
+const sinon = require('sinon')
+const md5 = require('md5')
+const fs = require('fs')
+
+/**
+ * Given an GET path, builds a local path unique to the query
+ */
+function fixturePath (url) {
+  // Use md5 on that to get a short, (mostly) unique string suitable as
+  // a filename.
+  return `./test/fixtures/query-${md5(url)}.json`
+}
+
+/**
+ * Enable data-api-client fixtures. Will attempt to serve static files from
+ * ./fixtures based on request URL.
+ *
+ * If process.env.UPDATE_FIXTURES=all, all fixtures will be updated (based on
+ * NYPL_API_BASE_URL).
+ *
+ * If process.env.UPDATE_FIXTURES=if-missing, only those fixtures that are
+ * missing will be updated (based on NYPL_API_BASE_URL). Useful for adding new
+ * fixtures without introducing trivial changes to existing.
+ */
+function enableFixtures () {
+  const NyplDataApiClient = require('@nypl/nypl-data-api-client')
+
+  // If tests are run with `UPDATE_FIXTURES=[all|if-missing] npm test`, rebuild fixtures:
+  if (process.env.UPDATE_FIXTURES) {
+    // Create a ref to the original get method, bound to a client instance:
+    const originalMethod = NyplDataApiClient.prototype.get.bind(new NyplDataApiClient())
+
+    sinon.stub(NyplDataApiClient.prototype, 'get').callsFake((url) => {
+      return fixtureExists(url).then((exists) => {
+        // If it doesn't exist, or we're updating everything, update it:
+        if (process.env.UPDATE_FIXTURES === 'all' || !exists) {
+          console.log(`Writing ${fixturePath(url)} because ${process.env.UPDATE_FIXTURES === 'all' ? 'we\'re updating everything' : 'it doesn\'t exist'}`)
+          return originalMethod(url, { authenticate: false })
+            // Now write the response to local fixture:
+            .then((resp) => writeResponseToFixture(url, resp))
+            // And for good measure, let's immediately rely on the local fixture:
+            .then(() => clientSearchViaFixtures(url))
+        } else {
+          return clientSearchViaFixtures(url)
+        }
+      })
+    })
+  } else {
+    // Any internal call to app.esClient.search should load a local fixture:
+    sinon.stub(NyplDataApiClient.prototype, 'get').callsFake(clientSearchViaFixtures)
+  }
+}
+
+/**
+ * Emulates NyplDataApiClient.prototype.get via local fixtures
+ */
+function clientSearchViaFixtures (url) {
+  const path = fixturePath(url)
+  return new Promise((resolve, reject) => {
+    fs.readFile(path, 'utf8', (err, content) => {
+      if (err) {
+        console.error(`Missing fixture (${path}) for `, url)
+        return reject(err)
+      }
+
+      return resolve(JSON.parse(content))
+    })
+  })
+}
+
+/**
+ * Determine if the fixture for the given query exists on disk, async.
+ *
+ * @returns {Promise<boolean>} A promise that resolves a boolean: true if fixture exists, false otherwise.
+ */
+function fixtureExists (url) {
+  let path = fixturePath(url)
+  return new Promise((resolve, reject) => {
+    fs.access(path, (err, fd) => {
+      const exists = !err
+      return resolve(exists)
+    })
+  })
+}
+
+/**
+ * Given a URL, this function:
+ *  - determines the fixture path and
+ *  - writes the given response to a local fixture
+ */
+function writeResponseToFixture (url, resp) {
+  let path = fixturePath(url)
+  return new Promise((resolve, reject) => {
+    fs.writeFile(path, JSON.stringify(resp, null, 2), (err, res) => {
+      if (err) return reject(err)
+
+      return resolve()
+    })
+  })
+}
+
+/**
+ * Use in `after/afterEach` to restore (de-mock)
+ */
+function disableFixtures () {
+  const nyplDataApiClient = require('@nypl/nypl-data-api-client')
+  nyplDataApiClient.prototype.get.restore()
+}
+
+module.exports = {
+  enableFixtures,
+  disableFixtures
+}

--- a/test/fixtures/query-497ed07447d37504974f4f6694b31932.json
+++ b/test/fixtures/query-497ed07447d37504974f4f6694b31932.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "id": 275,
+    "offsetBegin": 0,
+    "offsetEnd": 0,
+    "schemaObject": {
+      "name": "IndexDocumentProcessed",
+      "type": "record",
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "nyplSource",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "nyplType",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      ]
+    },
+    "stream": "IndexDocumentProcessed",
+    "schema": "{\"name\":\"IndexDocumentProcessed\",\"type\":\"record\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"nyplSource\",\"type\":[\"string\",\"null\"]},{\"name\":\"nyplType\",\"type\":[\"string\",\"null\"]}]}"
+  },
+  "count": 1,
+  "statusCode": 200,
+  "debugInfo": []
+}

--- a/test/fixtures/query-719a7eb463a3c665e480cd7b54a2501d.json
+++ b/test/fixtures/query-719a7eb463a3c665e480cd7b54a2501d.json
@@ -1,0 +1,357 @@
+{
+  "data": {
+    "id": 253,
+    "offsetBegin": 0,
+    "offsetEnd": 0,
+    "schemaObject": {
+      "name": "Bib",
+      "type": "record",
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "nyplSource",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "nyplType",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "updatedDate",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "createdDate",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "deletedDate",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "deleted",
+          "type": "boolean"
+        },
+        {
+          "name": "locations",
+          "type": [
+            "null",
+            {
+              "type": "array",
+              "items": [
+                {
+                  "name": "locations",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "code",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    {
+                      "name": "name",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "suppressed",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        {
+          "name": "lang",
+          "type": [
+            "null",
+            {
+              "name": "lang",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "code",
+                  "type": "string"
+                },
+                {
+                  "name": "name",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "title",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "author",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "materialType",
+          "type": [
+            "null",
+            {
+              "name": "materialType",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "code",
+                  "type": "string"
+                },
+                {
+                  "name": "value",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "bibLevel",
+          "type": [
+            "null",
+            {
+              "name": "bibLevel",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "code",
+                  "type": "string"
+                },
+                {
+                  "name": "value",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "publishYear",
+          "type": [
+            "int",
+            "null"
+          ]
+        },
+        {
+          "name": "catalogDate",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "country",
+          "type": [
+            "null",
+            {
+              "name": "country",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "code",
+                  "type": "string"
+                },
+                {
+                  "name": "name",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "normTitle",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "normAuthor",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "name": "fixedFields",
+          "type": [
+            "null",
+            {
+              "type": "map",
+              "values": [
+                {
+                  "name": "fixedField",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "label",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    {
+                      "name": "value",
+                      "type": [
+                        "string",
+                        "null",
+                        "boolean",
+                        "int"
+                      ]
+                    },
+                    {
+                      "name": "display",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "varFields",
+          "type": [
+            "null",
+            {
+              "type": "array",
+              "items": [
+                {
+                  "name": "varField",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "fieldTag",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    {
+                      "name": "marcTag",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    {
+                      "name": "ind1",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    {
+                      "name": "ind2",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    {
+                      "name": "content",
+                      "type": [
+                        "string",
+                        "null",
+                        "boolean"
+                      ]
+                    },
+                    {
+                      "name": "subfields",
+                      "type": [
+                        "null",
+                        {
+                          "type": "array",
+                          "items": [
+                            {
+                              "name": "subfield",
+                              "type": "record",
+                              "fields": [
+                                {
+                                  "name": "tag",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                {
+                                  "name": "content",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "stream": "Bib",
+    "schema": "{\n  \"name\": \"Bib\",\n  \"type\": \"record\",\n  \"fields\": [\n    {\n      \"name\": \"id\",\n      \"type\": \"string\"\n    },\n    {\n      \"name\": \"nyplSource\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"nyplType\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"updatedDate\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"createdDate\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"deletedDate\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"deleted\",\n      \"type\": \"boolean\"\n    },\n    {\n      \"name\": \"locations\",\n      \"type\": [\n        \"null\",\n        {\n          \"type\": \"array\",\n          \"items\": [\n            {\n              \"name\": \"locations\",\n              \"type\": \"record\",\n              \"fields\": [\n                {\n                  \"name\": \"code\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                },\n                {\n                  \"name\": \"name\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                }\n              ]\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"name\": \"suppressed\",\n      \"type\": [\n        \"boolean\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"lang\",\n      \"type\": [\n        \"null\",\n        {\n          \"name\": \"lang\",\n          \"type\": \"record\",\n          \"fields\": [\n            {\n              \"name\": \"code\",\n              \"type\": \"string\"\n            },\n            {\n              \"name\": \"name\",\n              \"type\": [\n                \"string\",\n                \"null\"\n              ]\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"name\": \"title\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"author\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"materialType\",\n      \"type\": [\n        \"null\",\n        {\n          \"name\": \"materialType\",\n          \"type\": \"record\",\n          \"fields\": [\n            {\n              \"name\": \"code\",\n              \"type\": \"string\"\n            },\n            {\n              \"name\": \"value\",\n              \"type\": [\n                \"string\",\n                \"null\"\n              ]\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"name\": \"bibLevel\",\n      \"type\": [\n        \"null\",\n        {\n          \"name\": \"bibLevel\",\n          \"type\": \"record\",\n          \"fields\": [\n            {\n              \"name\": \"code\",\n              \"type\": \"string\"\n            },\n            {\n              \"name\": \"value\",\n              \"type\": [\n                \"string\",\n                \"null\"\n              ]\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"name\": \"publishYear\",\n      \"type\": [\n        \"int\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"catalogDate\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"country\",\n      \"type\": [\n        \"null\",\n        {\n          \"name\": \"country\",\n          \"type\": \"record\",\n          \"fields\": [\n            {\n              \"name\": \"code\",\n              \"type\": \"string\"\n            },\n            {\n              \"name\": \"name\",\n              \"type\": [\n                \"string\",\n                \"null\"\n              ]\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"name\": \"normTitle\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"normAuthor\",\n      \"type\": [\n        \"string\",\n        \"null\"\n      ]\n    },\n    {\n      \"name\": \"fixedFields\",\n      \"type\": [\n        \"null\",\n        {\n          \"type\": \"map\",\n          \"values\": [\n            {\n              \"name\": \"fixedField\",\n              \"type\": \"record\",\n              \"fields\": [\n                {\n                  \"name\": \"label\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                },\n                {\n                  \"name\": \"value\",\n                  \"type\": [\n                    \"string\",\n                    \"null\",\n                    \"boolean\",\n                    \"int\"\n                  ]\n                },\n                {\n                  \"name\": \"display\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                }\n              ]\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"name\": \"varFields\",\n      \"type\": [\n        \"null\",\n        {\n          \"type\": \"array\",\n          \"items\": [\n            {\n              \"name\": \"varField\",\n              \"type\": \"record\",\n              \"fields\": [\n                {\n                  \"name\": \"fieldTag\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                },\n                {\n                  \"name\": \"marcTag\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                },\n                {\n                  \"name\": \"ind1\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                },\n                {\n                  \"name\": \"ind2\",\n                  \"type\": [\n                    \"string\",\n                    \"null\"\n                  ]\n                },\n                {\n                  \"name\": \"content\",\n                  \"type\": [\n                    \"string\",\n                    \"null\",\n                    \"boolean\"\n                  ]\n                },\n                {\n                  \"name\": \"subfields\",\n                  \"type\": [\n                    \"null\",\n                    {\n                      \"type\": \"array\",\n                      \"items\": [\n                        {\n                          \"name\": \"subfield\",\n                          \"type\": \"record\",\n                          \"fields\": [\n                            {\n                              \"name\": \"tag\",\n                              \"type\": [\n                                \"string\",\n                                \"null\"\n                              ]\n                            },\n                            {\n                              \"name\": \"content\",\n                              \"type\": [\n                                \"string\",\n                                \"null\"\n                              ]\n                            }\n                          ]\n                        }\n                      ]\n                    }\n                  ]\n                }\n              ]\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  },
+  "count": 1,
+  "statusCode": 200,
+  "debugInfo": []
+}

--- a/test/fixtures/query-a15b7fdeff166ff13c2e952121fcb0e3.json
+++ b/test/fixtures/query-a15b7fdeff166ff13c2e952121fcb0e3.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "id": 274,
+    "offsetBegin": 0,
+    "offsetEnd": 0,
+    "schemaObject": {
+      "fields": [
+        {
+          "name": "uri",
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "type": "string"
+        }
+      ],
+      "name": "IndexDocument",
+      "type": "record"
+    },
+    "stream": "IndexDocument",
+    "schema": "{\"fields\":[{\"name\":\"uri\",\"type\":\"string\"},{\"name\":\"type\",\"type\":\"string\"}],\"name\":\"IndexDocument\",\"type\":\"record\"}"
+  },
+  "count": 1,
+  "statusCode": 200,
+  "debugInfo": []
+}

--- a/test/fixtures/query-a6fbc70c7dd25664295da76321f949fe.json
+++ b/test/fixtures/query-a6fbc70c7dd25664295da76321f949fe.json
@@ -1,0 +1,35 @@
+{
+  "statusCode": 404,
+  "type": "exception",
+  "message": "No record found",
+  "error": {
+    "type": "NYPL\\Starter\\APIException",
+    "code": 0,
+    "message": "No record found",
+    "file": "/var/task/vendor/nypl/microservice-starter/src/Model/ModelTrait/DBReadTrait.php",
+    "line": 44,
+    "trace": [
+      "#0 /var/task/vendor/nypl/microservice-starter/src/Model/ModelTrait/DBReadTrait.php(245): NYPL\\Services\\Model\\DataModel\\BaseSchema\\Schema->setSingle(false)",
+      "#1 /var/task/vendor/nypl/microservice-starter/src/Controller.php(283): NYPL\\Services\\Model\\DataModel\\BaseSchema\\Schema->read()",
+      "#2 /var/task/src/Controller/SchemaController.php(397): NYPL\\Starter\\Controller->getDefaultReadResponse(Object(NYPL\\Services\\Model\\DataModel\\BaseSchema\\Schema), Object(NYPL\\Services\\Model\\Response\\SuccessResponse\\SchemasResponse))",
+      "#3 /var/task/index.php(44): NYPL\\Services\\Controller\\SchemaController->getCurrentSchema('IndexLaLaLa')",
+      "#4 [internal function]: Closure->{closure}(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response), Array)",
+      "#5 /var/task/vendor/slim/slim/Slim/Handlers/Strategies/RequestResponse.php(41): call_user_func(Object(Closure), Object(Slim\\Http\\Request), Object(Slim\\Http\\Response), Array)",
+      "#6 /var/task/vendor/slim/slim/Slim/Route.php(325): Slim\\Handlers\\Strategies\\RequestResponse->__invoke(Object(Closure), Object(Slim\\Http\\Request), Object(Slim\\Http\\Response), Array)",
+      "#7 /var/task/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(116): Slim\\Route->__invoke(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#8 /var/task/vendor/slim/slim/Slim/Route.php(297): Slim\\Route->callMiddlewareStack(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#9 /var/task/vendor/slim/slim/Slim/App.php(443): Slim\\Route->run(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#10 /var/task/vendor/nypl/microservice-starter/src/Service.php(60): Slim\\App->__invoke(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#11 [internal function]: NYPL\\Starter\\Service->NYPL\\Starter\\{closure}(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response), Object(NYPL\\Starter\\Service))",
+      "#12 /var/task/vendor/slim/slim/Slim/DeferredCallable.php(43): call_user_func_array(Object(Closure), Array)",
+      "#13 [internal function]: Slim\\DeferredCallable->__invoke(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response), Object(NYPL\\Starter\\Service))",
+      "#14 /var/task/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(67): call_user_func(Object(Slim\\DeferredCallable), Object(Slim\\Http\\Request), Object(Slim\\Http\\Response), Object(NYPL\\Starter\\Service))",
+      "#15 /var/task/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(116): Slim\\App->Slim\\{closure}(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#16 /var/task/vendor/slim/slim/Slim/App.php(337): Slim\\App->callMiddlewareStack(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#17 /var/task/vendor/slim/slim/Slim/App.php(298): Slim\\App->process(Object(Slim\\Http\\Request), Object(Slim\\Http\\Response))",
+      "#18 /var/task/index.php(47): Slim\\App->run()",
+      "#19 {main}"
+    ]
+  },
+  "debugInfo": []
+}

--- a/test/write-test.js
+++ b/test/write-test.js
@@ -1,28 +1,28 @@
 /* global describe it before after */
 
+const AWS = require('aws-sdk-mock')
 const assert = require('assert')
 const Client = require('../index')
 
 describe('Client', function () {
-  const TEMP_STREAM_NAME = 'node-nypl-streams-client-test-14948860293950.8801324877422303'
   const CLIENT_OPTS = { nyplDataApiClientBase: 'https://api.nypltech.org/api/v0.1/' }
 
+  // We have to ask for extra running time here because we test rate limits
   this.timeout(30000)
 
   before(() => {
-    // Create the temporary stream:
-    var client = new Client(CLIENT_OPTS)
-    return client.createStream(TEMP_STREAM_NAME)
+    // Mock AWS.Kinesis.prototype.putRecords
+    AWS.mock('Kinesis', 'putRecords', function (params, callback) {
+      callback(null, { FailedRecordCount: 0, Records: Array(params.Records.length) })
+    })
+    // Mock AWS.Kinesis.prototype.putRecord (singular)
+    AWS.mock('Kinesis', 'putRecord', function (params, callback) {
+      callback(null, 'That record, it is now put')
+    })
   })
 
   after(() => {
-    // If running tests a lot, consider setting PERSIST_TESTING_STREAMS=true
-    // so that you don't have to re-create the temporary stream each run:
-    if (process.env.PERSIST_TESTING_STREAMS) return Promise.resolve()
-
-    // Delete the temporary stream:
-    var client = new Client(CLIENT_OPTS)
-    return client.deleteStream(TEMP_STREAM_NAME, { yesIKnowThisIsPotentiallyDisastrous: true })
+    AWS.restore('Kinesis')
   })
 
   describe('Stream write', function () {
@@ -35,7 +35,7 @@ describe('Client', function () {
     it('should write single record to stream', function () {
       var client = new Client(CLIENT_OPTS)
 
-      return client.write(TEMP_STREAM_NAME, data, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
+      return client.write('fake-stream-name', data, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
         // By virtue of resolving, we know the creation was successful
         assert(true)
       })
@@ -46,9 +46,7 @@ describe('Client', function () {
 
       var num = 501
       var multiple = Array.apply(undefined, { length: num }).map(() => data)
-      return client.write(TEMP_STREAM_NAME, multiple, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
-        // console.log('resp: ', resp)
-
+      return client.write('fake-stream-name', multiple, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
         assert(resp)
         assert.equal(resp.FailedRecordCount, 0)
         assert.equal(resp.Records.length, num)
@@ -67,13 +65,12 @@ describe('Client', function () {
       var expectedTime = Math.floor(num / recordsPerSecond) * 1000
 
       var start = (new Date()).getTime()
-      return client.write(TEMP_STREAM_NAME, multiple, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
-        // console.log('resp: ', resp)
-
+      return client.write('fake-stream-name', multiple, { avroSchemaName: 'IndexDocumentProcessed' }).then((resp) => {
         assert(resp)
         assert.equal(resp.FailedRecordCount, 0)
         assert.equal(resp.Records.length, num)
 
+        // Make sure ellapsed time reflects rate limit
         var ellapsed = (new Date()).getTime() - start
         assert(ellapsed > expectedTime)
       })


### PR DESCRIPTION
This is a very chatty PR, so I'm happy to walk people through it. It does these things, in descending order of risk:

 -  Bumps data-api-client version to 1.0.0, which has been the current version for five months. DataApiClient 1.0.0 introduces [some breaking changes](https://github.com/NYPL-discovery/node-nypl-data-api-client/blob/master/CHANGELOG.md#breaking-changes), which this PR accounts for.
 - All tests now use stubs for all external dependencies rather than hit AWS infrastructure and the data api. Includes a method for adding/updating fixtures in the future.
 - Rearranges methods in lib/client to highlight public interface before private
 - Improves documentation substantially by:
   - Includes inline jsdoc comments attached to all public & private methods
   - Moves granular usage documentation out of README into a jsdoc file in docs/usage.md
   - Documents ideal git workflow 

If approved, this would be a `v1.0.0` version bump to bring us in line with our versioning standard.